### PR TITLE
Use shadcn components/patterns, add custom theme

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "cSpell.words": [
+    "elysiajs",
+    "tanstack"
+  ]
+}

--- a/services/frontend/src/components/Landing.tsx
+++ b/services/frontend/src/components/Landing.tsx
@@ -1,100 +1,39 @@
 import React from "react";
 import { useTheme } from "../hooks/useTheme";
-import { useNavigate } from "@tanstack/react-router"; 
+import { useNavigate } from "@tanstack/react-router";
 import darkAsset from "../assets/dark.png";
 import lightAsset from "../assets/light.png";
 import logo from "../assets/bonfire.png";
+import { Button } from "./ui/button";
 
 function Landing() {
-  const { theme, setTheme } = useTheme();
-  const navigate = useNavigate(); 
-
-  const toggleTheme = () => {
-    setTheme(theme.value === "light" ? "dark" : "light");
-  };
-
-  const handleLoginClick = () => {
-    navigate({to: "/login"});
-  };
+  const navigate = useNavigate({
+    from: "/",
+  });
 
   const handleGetStartedClick = () => {
-    navigate({to: "/register"});
+    navigate({ to: "/register" });
   };
 
   return (
-    <div
-      className={`min-h-screen w-full p-8 ${
-        theme.value === "light" ? "bg-[#F8F8F8]" : "bg-[#161616]"
-      }`}
-    >
-      <div className="flex justify-between items-center max-w-4xl mx-auto">
-        <div className="flex items-center">
-          <img src={logo} alt="Logo" className="h-8 w-8 mr-2" />
-          <h1
-            className={`text-xl ${
-              theme.value === "light" ? "text-black" : "text-white"
-            }`}
-          >
-            Fireside
-          </h1>
-        </div>
-        <div className="flex items-center">
-          <button onClick={toggleTheme} className="mr-3">
-            <img
-              src={theme.value === "light" ? lightAsset : darkAsset}
-              alt="Theme toggle"
-              className="h-6 w-6"
-            />
-          </button>
-          <div className="mx-3 h-6 w-px bg-gray-400"></div>
-          <button
-            onClick={handleLoginClick}  
-            className={`text-sm mr-3 ${
-              theme.value === "light" ? "text-black" : "text-white"
-            }`}
-          >
-            Log in
-          </button>
-          <button
-            onClick={handleGetStartedClick}
-            className={`px-4 py-2 rounded ${
-              theme.value === "light"
-                ? "bg-black text-white"
-                : "bg-white text-black"
-            }`}
-          >
-            Get Started
-          </button>
-        </div>
-      </div>
-      <div className="text-center mt-16">
-        <h2
-          className={`text-5xl font-bold mt-24 ${
-            theme.value === "light" ? "text-black" : "text-white"
-          }`}
-        >
-          Empowering Education,
-          <br />
-          one connection at a time.
-        </h2>
-        <p
-          className={`mt-8 ${
-            theme.value === "light" ? "text-black" : "text-white"
-          }`}
-        >
-          Fireside is the connected workspace where students get answers
-        </p>
-        <button
-          onClick={handleGetStartedClick} 
-          className={`mt-10 px-6 py-3 rounded font-bold ${
-            theme.value === "light"
-              ? "bg-black text-white"
-              : "bg-white text-black"
-          }`}
-        >
-          Get Started
-        </button>
-      </div>
+    <div className="text-center mt-16 w-full">
+      <h2 className={`text-5xl font-bold mt-24 `}>
+        Empowering Education,
+        <br />
+        one connection at a time.
+      </h2>
+      <p className={`mt-8 `}>
+        Fireside is the connected workspace where students get answers
+      </p>
+      <Button
+        size={"lg"}
+        onClick={handleGetStartedClick}
+        className={
+          "mt-10 px-6 py-3 rounded font-bold bg-foreground text-white dark:text-black"
+        }
+      >
+        Get Started
+      </Button>
     </div>
   );
 }

--- a/services/frontend/src/components/Login.tsx
+++ b/services/frontend/src/components/Login.tsx
@@ -1,79 +1,34 @@
-import React from "react";
-import { Button } from "@/components/ui/button";
-import logo from "../assets/bonfire.png";
-import { useTheme } from "@/hooks/useTheme";
 import { useNavigate } from "@tanstack/react-router";
+import { Button } from "./ui/button";
+import { Input } from "./ui/input";
 
 function Login() {
-  const { theme } = useTheme();
-  const navigate = useNavigate();
-
-  const navigateHome = () => {
-    navigate({ to: "/" });
-  };
-
+  const navigate = useNavigate({ from: "/login" });
   return (
-    <div
-      className={`flex flex-col justify-between min-h-screen w-full ${
-        theme.value === "light" ? "bg-[#F8F8F8]" : "bg-[#161616]"
-      }`}
-    >
-      <div className="p-8">
-        <div className="flex justify-between items-center max-w-4xl mx-auto">
-          <div
-            className="flex items-center cursor-pointer"
-            onClick={navigateHome}
-          >
-            <img src={logo} alt="Logo" className="h-8 w-8 mr-2" />
-            <h1
-              className={`text-xl ${
-                theme.value === "light" ? "text-black" : "text-white"
-              }`}
-            >
-              Fireside
-            </h1>
-          </div>
-        </div>
-      </div>
-
-      <div className="flex flex-col items-center justify-center flex-grow">
-        <h2
-          className={`text-3xl font-bold mb-10 ${
-            theme.value === "light" ? "text-black" : "text-white"
-          }`}
-        >
-          Log in
-        </h2>
+    <div className={`flex flex-col justify-between min-h-screen w-full `}>
+      <div className="flex flex-col items-center justify-start flex-grow pt-32">
+        <h2 className={`text-5xl font-semibold mb-10 `}>Sign Up</h2>
         <div className="w-full max-w-xs">
           <div className="space-y-4 mb-6">
             {["Email", "Password"].map((label, index) => (
               <div key={index}>
-                <label
-                  className={`block text-sm font-medium ${
-                    theme.value === "light" ? "text-black" : "text-white"
-                  }`}
-                >
-                  {label}
-                </label>
-                <input
+                <label className={`block text-sm font-medium`}>{label}</label>
+                <Input
                   type={label === "Email" ? "email" : "password"}
                   placeholder={`${label}`}
-                  className={`mt-1 w-full rounded p-2 ${
-                    theme.value === "light"
-                      ? "bg-[#E6E6E6] border-[#C1C1C1]"
-                      : "bg-[#232323] border-[#232323]"
-                  } border text-sm`}
+                  className={`mt-1 w-full rounded p-2 border-secondary/70 border text-sm text-black`}
                 />
               </div>
             ))}
           </div>
-          <button
-            className={`w-full py-2 rounded font-bold text-white ${
-              theme.value === "light" ? "bg-[#FBCE76]" : "bg-[#FCAB6B]"
-            }`}
+          <Button
+            onClick={() => {
+              navigate({ to: "/" });
+            }}
+            className={`w-full py-2 rounded font-bold text-white`}
           >
             Continue
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/services/frontend/src/components/Login.tsx
+++ b/services/frontend/src/components/Login.tsx
@@ -16,7 +16,7 @@ function Login() {
                 <Input
                   type={label === "Email" ? "email" : "password"}
                   placeholder={`${label}`}
-                  className={`mt-1 w-full rounded p-2 border-secondary/70 border-2 text-sm text-black`}
+                  className={`mt-1 w-full rounded p-2 border-secondary/70 border-2 text-sm `}
                 />
               </div>
             ))}

--- a/services/frontend/src/components/Login.tsx
+++ b/services/frontend/src/components/Login.tsx
@@ -16,7 +16,7 @@ function Login() {
                 <Input
                   type={label === "Email" ? "email" : "password"}
                   placeholder={`${label}`}
-                  className={`mt-1 w-full rounded p-2 border-secondary/70 border text-sm text-black`}
+                  className={`mt-1 w-full rounded p-2 border-secondary/70 border-2 text-sm text-black`}
                 />
               </div>
             ))}

--- a/services/frontend/src/components/Register.tsx
+++ b/services/frontend/src/components/Register.tsx
@@ -16,7 +16,7 @@ function Register() {
                 <Input
                   type={label === "Email" ? "email" : "password"}
                   placeholder={`${label}`}
-                  className={`mt-1 w-full rounded p-2 border-secondary/70 border text-sm text-black`}
+                  className={`mt-1 w-full rounded p-2 border-secondary/90 dark:border-2 text-sm text-black`}
                 />
               </div>
             ))}
@@ -27,7 +27,7 @@ function Register() {
               <Input
                 type={"password"}
                 placeholder={"Confirm Password"}
-                className={`mt-1 w-full rounded p-2 dark:bg-secondary border-secondary bg-muted border text-sm`}
+                className={`mt-1 w-full rounded p-2 dark:bg-secondary border-secondary/90 dark:border-2 bg-muted text-sm`}
               />
             </div>
           </div>

--- a/services/frontend/src/components/Register.tsx
+++ b/services/frontend/src/components/Register.tsx
@@ -1,78 +1,44 @@
-import React from "react";
-import { useTheme } from "../hooks/useTheme";
-import logo from "../assets/bonfire.png";
 import { useNavigate } from "@tanstack/react-router";
+import { Button } from "./ui/button";
+import { Input } from "./ui/input";
 
 function Register() {
-  const { theme } = useTheme();
-  const navigate = useNavigate();
-
-  const navigateHome = () => {
-    navigate({ to: "/" });
-  };
-
+  const navigate = useNavigate({ from: "/register" });
   return (
-    <div
-      className={`flex flex-col justify-between min-h-screen w-full ${
-        theme.value === "light" ? "bg-[#F8F8F8]" : "bg-[#161616]"
-      }`}
-    >
-      <div className="p-8">
-        <div className="flex justify-between items-center max-w-4xl mx-auto">
-          <div
-            className="flex items-center cursor-pointer"
-            onClick={navigateHome}
-          >
-            <img src={logo} alt="Logo" className="h-8 w-8 mr-2" />
-            <h1
-              className={`text-xl ${
-                theme.value === "light" ? "text-black" : "text-white"
-              }`}
-            >
-              Fireside
-            </h1>
-          </div>
-        </div>
-      </div>
-
-      <div className="flex flex-col items-center justify-center flex-grow">
-        <h2
-          className={`text-5xl font-semibold mb-10 bototm-10 ${
-            theme.value === "light" ? "text-black" : "text-white"
-          }`}
-        >
-          Sign Up
-        </h2>
+    <div className={`flex flex-col justify-between min-h-screen w-full `}>
+      <div className="flex flex-col items-center justify-start flex-grow pt-32">
+        <h2 className={`text-5xl font-semibold mb-10 `}>Sign Up</h2>
         <div className="w-full max-w-xs">
           <div className="space-y-4 mb-6">
-            {["Email", "Password", "Confirm Password"].map((label, index) => (
+            {["Email", "Password"].map((label, index) => (
               <div key={index}>
-                <label
-                  className={`block text-sm font-medium ${
-                    theme.value === "light" ? "text-black" : "text-white"
-                  }`}
-                >
-                  {label}
-                </label>
-                <input
+                <label className={`block text-sm font-medium`}>{label}</label>
+                <Input
                   type={label === "Email" ? "email" : "password"}
                   placeholder={`${label}`}
-                  className={`mt-1 w-full rounded p-2 ${
-                    theme.value === "light"
-                      ? "bg-[#E6E6E6] border-[#C1C1C1]"
-                      : "bg-[#232323] border-[#232323]"
-                  } border text-sm`}
+                  className={`mt-1 w-full rounded p-2 border-secondary/70 border text-sm text-black`}
                 />
               </div>
             ))}
+            <div>
+              <label className={`block text-sm font-medium`}>
+                Confirm Password
+              </label>
+              <Input
+                type={"password"}
+                placeholder={"Confirm Password"}
+                className={`mt-1 w-full rounded p-2 dark:bg-secondary border-secondary bg-muted border text-sm`}
+              />
+            </div>
           </div>
-          <button
-            className={`w-full py-2 rounded font-bold text-white ${
-              theme.value === "light" ? "bg-[#FBCE76]" : "bg-[#FCAB6B]"
-            }`}
+          <Button
+            onClick={() => {
+              navigate({ to: "/" });
+            }}
+            className={`w-full py-2 rounded font-bold text-white`}
           >
             Continue
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/services/frontend/src/components/Register.tsx
+++ b/services/frontend/src/components/Register.tsx
@@ -16,7 +16,7 @@ function Register() {
                 <Input
                   type={label === "Email" ? "email" : "password"}
                   placeholder={`${label}`}
-                  className={`mt-1 w-full rounded p-2 border-secondary/90 dark:border-2 text-sm text-black`}
+                  className={`mt-1 w-full rounded p-2 border-secondary/90 dark:border-2 text-sm `}
                 />
               </div>
             ))}

--- a/services/frontend/src/components/ui/input.tsx
+++ b/services/frontend/src/components/ui/input.tsx
@@ -1,0 +1,25 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/services/frontend/src/index.css
+++ b/services/frontend/src/index.css
@@ -1,71 +1,54 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
- 
+
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
-
-    --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
- 
-    --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
- 
-    --primary: 222.2 47.4% 11.2%;
-    --primary-foreground: 210 40% 98%;
- 
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
- 
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
- 
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
- 
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
-
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
- 
-    --radius: 0.5rem;
+    --background: 28 0% 95%;
+    --foreground: 28 0% 7%;
+    --card: 28 0% 90%;
+    --card-foreground: 28 0% 10%;
+    --popover: 28 0% 95%;
+    --popover-foreground: 28 95% 7%;
+    --primary: 28 85.4% 62.4%;
+    --primary-foreground: 0 0% 0%;
+    --secondary: 28 10% 70%;
+    --secondary-foreground: 0 0% 0%;
+    --muted: -10 10% 85%;
+    --muted-foreground: 28 0% 35%;
+    --accent: -10 10% 80%;
+    --accent-foreground: 28 0% 10%;
+    --destructive: 0 50% 30%;
+    --destructive-foreground: 28 0% 90%;
+    --border: 28 20% 50%;
+    --input: 28 20% 18%;
+    --ring: 28 85.4% 62.4%;
+    --radius: 0.3rem;
   }
- 
   .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
- 
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
- 
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
- 
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
- 
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
- 
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
- 
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
- 
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
- 
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
+    --background: 28 10% 7%;
+    --foreground: 28 0% 90%;
+    --card: 28 0% 7%;
+    --card-foreground: 28 0% 90%;
+    --popover: 28 10% 5%;
+    --popover-foreground: 28 0% 90%;
+    --primary: 28 85.4% 62.4%;
+    --primary-foreground: 0 0% 0%;
+    --secondary: 28 10% 10%;
+    --secondary-foreground: 0 0% 100%;
+    --muted: -10 10% 15%;
+    --muted-foreground: 28 0% 60%;
+    --accent: -10 10% 15%;
+    --accent-foreground: 28 0% 90%;
+    --destructive: 0 50% 30%;
+    --destructive-foreground: 28 0% 90%;
+    --border: 28 20% 18%;
+    --input: 28 20% 18%;
+    --ring: 28 85.4% 62.4%;
+    --radius: 0.3rem;
   }
 }
- 
+
 @layer base {
   * {
     @apply border-border;

--- a/services/frontend/src/main.tsx
+++ b/services/frontend/src/main.tsx
@@ -1,12 +1,15 @@
+import "./index.css";
 import React from "react";
 import ReactDOM from "react-dom/client";
-// import { logMe } from "@fireside/backend";
 import { edenTreaty } from "@elysiajs/eden";
-import "./index.css";
 import { z } from "zod";
 import type { App } from "@fireside/backend";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-// import { run, test } from "@fireside/utils";
+import { useNavigate } from "@tanstack/react-router";
+import darkAsset from "./assets/dark.png";
+import lightAsset from "./assets/light.png";
+import logo from "./assets/bonfire.png";
+
 import {
   createRootRouteWithContext,
   createRoute,
@@ -15,21 +18,12 @@ import {
   Outlet,
   RouterProvider,
 } from "@tanstack/react-router";
-import {
-  QueryClient,
-  QueryClientProvider,
-  // useMutation,
-  // useQuery,
-  useQueryClient,
-  // useSuspenseQuery,
-} from "@tanstack/react-query";
-// import { Button } from "./components/ui/button";
-import { ThemeProvider /*, useTheme */ } from "./hooks/useTheme";
-// import { User } from "../../db/src/schema";
-// import { useToast } from "./components/ui/use-toast";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ThemeProvider, useTheme } from "./hooks/useTheme";
 import Landing from "./components/Landing";
 import Login from "./components/Login";
 import Register from "./components/Register";
+import { Button } from "./components/ui/button";
 
 const envSchema = z.object(
   {
@@ -51,49 +45,55 @@ declare global {
 }
 
 const client = edenTreaty<App>(import.meta.env.VITE_API_URL);
-const userQueryOptions = {
-  queryKey: ["users"],
-  queryFn: async () => {
-    await new Promise((res) => {
-      setTimeout(() => {
-        res(null);
-      }, 1000);
-    });
-
-    return (await client.test.get()).data?.users ?? [];
-  },
-};
 
 function RootComponent() {
-  // const { theme, setTheme } = useTheme();
-  // const userQuery = useSuspenseQuery(userQueryOptions);
-  const queryClient = useQueryClient();
-  // const { toast } = useToast();
-  // const createUserMutation = useMutation({
-  //   mutationFn: (userInfo: { displayName: string }) =>
-  //     client.user.create.post(userInfo),
-  //   onSuccess: (res) => {
-  //     if (res.error) {
-  //       toast({
-  //         variant: "destructive",
-  //         title: "Failed to create user",
-  //         description: res.error.message,
-  //       });
-  //       return;
-  //     }
-  //     queryClient.setQueriesData<Array<User>>(userQueryOptions, (prev) =>
-  //       prev ? [...prev, res.data] : [res.data]
-  //     );
-  //   },
-  // });
+  const { theme, setTheme } = useTheme();
+  const navigate = useNavigate({
+    from: "/",
+  });
+
+  const toggleTheme = () => {
+    setTheme(theme.value === "light" ? "dark" : "light");
+  };
+
+  const handleLoginClick = () => {
+    navigate({ to: "/login" });
+  };
 
   return (
-    <div className="min-h-screen  flex flex-col items-start w-screen">
-      <div className="w-full flex">
-        {/* <Link to="/">Home</Link> */}
-        {/* Button logic commented out */}
+    <div className="min-h-screen  flex flex-col items-start w-screen justify-start">
+      <div className="flex justify-between items-center mx-auto w-full px-10 pt-5">
+        <Link to="/" className="flex items-center">
+          <img src={logo} alt="Logo" className="h-8 w-8 mr-2" />
+          <span className={`text-xl`}>Fireside</span>
+        </Link>
+        <div className="flex items-center">
+          <Button variant={"ghost"} onClick={toggleTheme} className="mr-3">
+            <img
+              src={theme.value === "light" ? lightAsset : darkAsset}
+              alt="Theme toggle"
+              className="h-6 w-6"
+            />
+          </Button>
+          <div className="mx-3 h-6 w-px bg-foreground"></div>
+          <Button
+            variant={"ghost"}
+            onClick={handleLoginClick}
+            className={`text-sm mr-3 `}
+          >
+            Log in
+          </Button>
+          <Button
+            variant={"ghost"}
+            onClick={() => {
+              navigate({ to: "/register" });
+            }}
+            className={`px-4 py-2 rounded`}
+          >
+            Get Started
+          </Button>
+        </div>
       </div>
-      {/* User mutation and query display logic commented out */}
       <Outlet />
       <ReactQueryDevtools buttonPosition="bottom-left" />
     </div>
@@ -126,7 +126,11 @@ const loginPageRoute = createRoute({
 
 const queryClient = new QueryClient();
 
-const routeTree = rootRoute.addChildren([landingPageRoute, registerPageRoute, loginPageRoute]);
+const routeTree = rootRoute.addChildren([
+  landingPageRoute,
+  registerPageRoute,
+  loginPageRoute,
+]);
 
 const router = createRouter({
   routeTree,


### PR DESCRIPTION
Made some changes to ur components to use shadcn styles/patterns so you can have a reference in the future :). The pages looked awesome, tried to keep it as close as possible to what u alrdy had

- Something cool with shadcn + tailwind is in our index.css we have base styles and ```dark:``` styles- the dark/light styles automatically apply when we toggle to dark/light mode. And if u need if statements for theme type u can use ```dark:<dark-style``` and it will only apply in dark mode
- Something else cool is u can reference the base style for the mode with colors called "background, primary, secondary, accent, foreground, ..." so u can do bg-background, or bg-primary and those will dynamically change based on the theme color 
- Moved some stuff to the root layout like navbar so it's applied by default on all pages
- Added a custom theme for our pallet, there are cool websites like [this](https://zippystarter.com/tools/shadcn-ui-theme-generator) that auto gen the CSS config for a shadcn theme.